### PR TITLE
Replace path concatenations with `os.path.join`

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -101,14 +101,14 @@ class SemanticSegmentation:
         if self.parameters["use_CPU_only"]:
             model.load_state_dict(
                 torch.load(
-                    get_fsct_path("model") + "/" + self.parameters["model_filename"],
+                    os.path.join(get_fsct_path("model"), self.parameters["model_filename"]),
                     map_location=torch.device("cpu"),
                 ),
                 strict=False,
             )
         else:
             model.load_state_dict(
-                torch.load(get_fsct_path("model") + "/" + self.parameters["model_filename"]),
+                torch.load(os.path.join(get_fsct_path("model"), self.parameters["model_filename"])),
                 strict=False,
             )
 


### PR DESCRIPTION
This PR aims to change the non-cross-platform uses of `/` into `os.path.join`. See [this SO thread for reasons why](https://stackoverflow.com/questions/13944387/why-use-os-path-join-over-string-concatenation).

I could be wrong in that this does not work on this repo for whatever reason, but I suspect this might be a solution to #25 

I do not work on this project and have 0 clue about the goals and aims of this project, so I could be wrong in assuming this would be a beneficial change, do feel free to reject the PR in that case!

I do understand that this change is not well propagated throughout the file. Since I cannot run this (I don't have data), I cannot really test this. I am collaborating with @msamin23 to test and validate this PR.